### PR TITLE
Modify to accept moment object instead of Date

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -12,7 +12,7 @@ function CronTime(source, zone) {
 		that[timeUnit] = {};
 	});
 
-	if (this.source instanceof Date) {
+	if (this.source instanceof Date || this.source instanceof moment) {
 		this.source = moment(this.source);
 		this.realDate = true;
 	} else {


### PR DESCRIPTION
Right now, if you pass a moment object instead of a JavaScript date, it crashes at line 267 saying "this.source.replace is not a function." This change will accept either a Date or Moment object.
