### PR TITLE
Accept Moment Object

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -12,7 +12,7 @@ function CronTime(source, zone) {
 		that[timeUnit] = {};
 	});
 
-	if (this.source instanceof Date) {
+	if (this.source instanceof Date || this.source._isAMomentObject) {
 		this.source = moment(this.source);
 		this.realDate = true;
 	} else {


### PR DESCRIPTION
Right now, if you pass a moment object instead of a date, the module crashes. This change enables you to pass a moment object or a JavaScript Date object.
